### PR TITLE
chore: upgrade node v14 to v20

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,7 +5,7 @@ on:
     branches: [ main ]
 
 env:
-  node_version: "14"
+  node_version: "20"
 
 jobs:
   publish:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@byu-oit/umzug-storage-dynamodb",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "DynamoDB storage for Umzug migration logs.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Node v14 reached end-of-life-status last year, this upgrades the package to use Node v20.